### PR TITLE
Add Elasticsearch 9, 8.18 and 8.17 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  tests_8_16:
+  tests_9_0:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -22,10 +22,27 @@ jobs:
       - uses: ./.github/actions/pytest
         with:
           python-version: ${{ matrix.python-version }}
-          elasticsearch: "8.16.1"
-  tests_8_15:
-    needs: [tests_8_16]
+          elasticsearch: "9.0"
+  tests_8_18:
     runs-on: ubuntu-latest
+    needs: [tests_9_0]
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
+    env:
+      OS: ubuntu-latest
+      PYTHON: ${{ matrix.python-version }}
+      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pytest
+        with:
+          python-version: ${{ matrix.python-version }}
+          elasticsearch: "8.18"
+  tests_8_17:
+    runs-on: ubuntu-latest
+    needs: [tests_8_18]
     strategy:
       fail-fast: true
       matrix:
@@ -39,14 +56,48 @@ jobs:
       - uses: ./.github/actions/pytest
         with:
           python-version: ${{ matrix.python-version }}
-          elasticsearch: "8.15"
-  tests_8_14:
-    needs: [tests_8_15]
+          elasticsearch: "8.17"
+  tests_8_16:
+    runs-on: ubuntu-latest
+    needs: [tests_8_17]
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "pypy-3.10"]
+    env:
+      OS: ubuntu-latest
+      PYTHON: ${{ matrix.python-version }}
+      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pytest
+        with:
+          python-version: ${{ matrix.python-version }}
+          elasticsearch: "8.16"
+  tests_8_15:
+    needs: [tests_8_16]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.13"]
+    env:
+      OS: ubuntu-latest
+      PYTHON: ${{ matrix.python-version }}
+      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pytest
+        with:
+          python-version: ${{ matrix.python-version }}
+          elasticsearch: "8.15"
+  tests_8_14:
+    needs: [tests_8_16]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.13"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -57,57 +108,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           elasticsearch: "8.14"
-  tests_8_13:
-    needs: [tests_8_14]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.13"]
-    env:
-      OS: ubuntu-latest
-      PYTHON: ${{ matrix.python-version }}
-      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/pytest
-        with:
-          python-version: ${{ matrix.python-version }}
-          elasticsearch: "8.13"
-  tests_8_12:
-    needs: [tests_8_14]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.13"]
-    env:
-      OS: ubuntu-latest
-      PYTHON: ${{ matrix.python-version }}
-      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/pytest
-        with:
-          python-version: ${{ matrix.python-version }}
-          elasticsearch: "8.12"
-  tests_8_11:
-    needs: [tests_8_14]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.13"]
-    env:
-      OS: ubuntu-latest
-      PYTHON: ${{ matrix.python-version }}
-      ES_JAVA_OPTS: "-Xms256m -Xmx512m"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/pytest
-        with:
-          python-version: ${{ matrix.python-version }}
-          elasticsearch: "8.11"
   tests_7_17:
     runs-on: ubuntu-22.04
     strategy:

--- a/newsfragments/+67bf9a67.misc.rst
+++ b/newsfragments/+67bf9a67.misc.rst
@@ -1,0 +1,1 @@
+Include elasticsearch 9.0, 8.17 and 8.18 in CI.


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number
